### PR TITLE
Add project role to folder service account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,11 @@ module "folder_service_account" {
       "roles/monitoring.viewer",
     ]
   }
+  iam_project_roles = {
+    "${var.project_name}" = [
+      "roles/monitoring.viewer",
+    ]
+  }
 }
 
 // If we're just granting access to a project AND creating the service account.

--- a/variables.tf
+++ b/variables.tf
@@ -1,25 +1,21 @@
 variable "project_name" {
   description = "(Required) Project name where service account will be created."
   type        = string
-  default     = ""
 }
 
 variable "service_account_create" {
   description = "(Required) Create a new service account"
   type        = bool
-  default     = false
 }
 
 variable "grafana_datasource_name" {
   description = "(Required) Name for Grafana Datasource - only required when service_account_create is true"
   type        = string
-  default     = ""
 }
 
 variable "service_account_name" {
   description = "(Required) Name for service account"
   type        = string
-  default     = ""
 }
 
 variable "grant_folder_permissions" {


### PR DESCRIPTION
The reasoning behind granting a service account metrics reader on a folder is so the data source is configured before a project is created, provided the folder exists. That, and also to avoid creating a data source for every project under a folder.

To achieve this  the service account needs to belong to another, existing, project.
The data source, however, fails to validate unless the service account can query metrics its project.

This PR grants the folder service account metric reader in the project it's created in. All projects created under the folder will show up in the GCP Project drop down in the GCM plugin