### PR TITLE
Fix key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,6 @@ resource "grafana_data_source" "stackdriver_folder" {
   }
 
   secure_json_data {
-    private_key = module.folder_service_account[0].key.private_key
+    private_key = jsondecode(base64decode(nonsensitive(module.folder_service_account[0].key.private_key))).private_key
   }
 }


### PR DESCRIPTION
The Grafana API wants the `private_key` value from the service account key.
It's a little bit confusing because the actual JSON service account key is the `private_key` output from the service account module, whose value is sensitive and base64-encoded, so in order to pull only the bit Grafana wants you need to make it nonsensitive, base64decode, parse the service account key json and reference the `private_key` element.

But why does pasting the whole service account key in the Grafana UI work?
Because it parses the key and only sends `-----BEGIN PRIVATE KEY-----\n....` 😀