### PR TITLE
Creating name/uid outputs that can be referenced by parent module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,11 +6,11 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.88.0"
+      version = "~> 4.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.88.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "datasource_name" {
+  value = var.service_account_create && var.grant_folder_permissions ? grafana_data_source.stackdriver_folder[0].name : grafana_data_source.stackdriver_project[0].name
+}
+
+output "datasource_uid" {
+  value = var.service_account_create && var.grant_folder_permissions ? grafana_data_source.stackdriver_folder[0].uid : grafana_data_source.stackdriver_project[0].uid
+}


### PR DESCRIPTION
Creating these outputs is necessary for use in the new way we have laid out the reference infrastructure. These outputs are needed as inputs to the `grafana_dashboards` module.

The google provider version updates are necessary for use in the updated infrastructure repos as well as there are several projects that require using versions >= 4.0

Contributes to https://github.com/dapperlabs/SRE/issues/2842